### PR TITLE
Fix on setting root password

### DIFF
--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -4,20 +4,20 @@
 # FLUSH PRIVILEGES;
 
 - name: Set root Password
-  mysql_user: name=root host={{ item }} password={{ mysql_root_password }} state=present
+  mysql_user: login_password={{ mysql_root_password }} check_implicit_admin=yes name=root host={{ item }} password={{ mysql_root_password }} state=present 
   with_items:
     - localhost
     - 127.0.0.1
     - ::1
+
+- name: Add .my.cnf
+  template: src=my.cnf.j2 dest=/root/.my.cnf owner=root group=root mode=0600
 
 - name: Reload privilege tables
   command: 'mysql -ne "{{ item }}"'
   with_items:
     - FLUSH PRIVILEGES
   changed_when: False
-
-- name: Add .my.cnf
-  template: src=my.cnf.j2 dest=/root/.my.cnf owner=root group=root mode=0600
 
 - name: Remove anonymous users
   command: 'mysql -ne "{{ item }}"'


### PR DESCRIPTION
Due to the nature of 'Set root password', the second entry and third item will fail (127.0.0.1 and ::1) because the password was already set for root@localhost. 
check_implicit_admin will first try to connect without password (for localhost) and will set the mysql_root_password.
Any other entry, check_implicit_admin will fail and it will fall back to using login_password, which was set in the first entry.

Re-ordered adding ~/.my.cnf as second task to run.